### PR TITLE
Improve logging when using It, ItTmp and such

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -23,7 +23,12 @@ type Assert struct {
 }
 
 func (a *Assert) clone(t *testing.T) *Assert {
-	return &Assert{t, a.stack, a.os, a.as}
+	fn := t.Errorf
+	f := os.Getenv("GO_ASSERT_FATAL")
+	if f == "true" || f == "t" || f == "1" {
+		fn = t.Fatalf
+	}
+	return &Assert{t, a.stack, a.os, fn}
 }
 
 // New creates a new Assert object.


### PR DESCRIPTION
The logging system does not properly use the logging system when using `Run()`, as the message passed as argument to the `It`, `ItTmp`, `ItEnv` and such does not show when the test fails.

This due to `Clone()` using the same function for the `as` field for the new instance of `Assert`, instead of using the `Errorf()` or `Fatalf()` functions from the new `*testing.T`.

This pull requests aims at solving this problem by using functions from the `t` passed as parameter, so that this snippet:

```
func TestWithSubTest(t *testing.T) {
  New(t).It(
    "sub test", func(a *Assert) {
      a.True(false)
    })
}
```
fails like this:

```
--- FAIL: TestWithSubTest (0.00s)
    --- FAIL: TestWithSubTest/sub_test (0.00s)
        /path/to/go-assert/assert.go:88: Error:
            Not true
```

